### PR TITLE
Add emacs to the gcc testplan

### DIFF
--- a/scratch-build.sh
+++ b/scratch-build.sh
@@ -98,6 +98,8 @@ elif [ ${nvrs} == llvm -o ${nvrs} == clang ]; then
     components="clang llvm kernel"
 elif [[ ${nvrs} == *binutils* ]]; then
     components="kernel lua opencryptoki strace glibc"
+elif [[ ${nvrs} == *gcc* ]]; then
+    components="kernel lua opencryptoki strace emacs"
 else
     components="kernel lua opencryptoki strace"
 fi


### PR DESCRIPTION
Looks like emacs is one of few users of libgccjit and its rebuild is a good "real world" test of the library. Suggested by dmalcolm.