### PR TITLE
Increase timeout of the scratch build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -92,6 +92,7 @@ pipeline {
             }
 
             steps {
+        		timeout(time: 12, unit: 'HOURS', activity: true)
                 checkout scm
 
                 sendMessage(type: 'running', artifactId: artifactId, pipelineMetadata: pipelineMetadata, dryRun: isPullRequest())


### PR DESCRIPTION
See all of the failing builds with state (aborted) https://osci-jenkins-1.ci.fedoraproject.org/job/fedora-ci/job/dist-git-build-pipeline/view/default/builds