### PR TITLE
Koji 502 workaround: try using user config file instead

### DIFF
--- a/scratch-build.sh
+++ b/scratch-build.sh
@@ -76,7 +76,9 @@ rpm -qa | fgrep -e coreutils -e koji -e fedpkg | sort
 
 # workaround Koji 502 errors:
 # https://pagure.io/fedora-infrastructure/issue/12913#comment-993744
-echo "anon_retry = true" >> /etc/koji.conf
+mkdir -p ~/.koji
+echo "[koji]" >> ~/.koji/config
+echo "anon_retry = true" >> ~/.koji/config
 
 # # set up email support
 # dnf --skip-broken -y install mailx sendmail


### PR DESCRIPTION
Looks like we aren't root so can't write to /etc/koji.conf. Try using ~/.koji/config instead.