### PR TITLE
Remove the 502 workaround

### DIFF
--- a/scratch-build.sh
+++ b/scratch-build.sh
@@ -74,12 +74,6 @@ set -x
 cat /etc/os-release
 rpm -qa | fgrep -e coreutils -e koji -e fedpkg | sort
 
-# workaround Koji 502 errors:
-# https://pagure.io/fedora-infrastructure/issue/12913#comment-993744
-mkdir -p ~/.koji
-echo "[koji]" >> ~/.koji/config
-echo "anon_retry = true" >> ~/.koji/config
-
 # # set up email support
 # dnf --skip-broken -y install mailx sendmail
 # myip=$(ip a | fgrep glo | fgrep -v 192 | tr '/' ' ' | awk '{print $2}')


### PR DESCRIPTION
@AdamWill Remembered when we were asking ourselves if these jobs run in container? Apparently they don't so this thing just created the section again and again :sweat_smile:. Confident that that's the case since [dist-git-pipeline](https://osci-jenkins-1.ci.fedoraproject.org/job/fedora-ci/job/dist-git-build-pipeline/job/master/54872/console) is also having the same failure. Let's move these to the testing-farm/infrastructure, and I will try to recover the workers manually while keeping the effective change until next re-deployment

ping @vkadlcik if this can be merged early