### PR TITLE
Switch to pubsub queue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,10 +39,10 @@ pipeline {
            noSquash: true,
            providerList: [
                rabbitMQSubscriber(
-                   name: 'RabbitMQ-public',
+                   name: 'RabbitMQ',
                    overrides: [
                        topic: 'org.fedoraproject.prod.bodhi.update.status.testing.koji-build-group.build.complete',
-                       queue: '8d8bb00d-03d6-48e1-936a-05d22c728224'
+                       queue: 'osci-pipelines-queue-scratch-build-test'
                    ],
                    checks: [
                        [field: '$.update.release.dist_tag', expectedValue: '^f[3-9]{1}[0-9]{1}$'],


### PR DESCRIPTION
The public one's certificate will be dropped in 1-2 months. Afaiu though there is no functional difference from using the generic `RabbitMQ` queue pointing to `/pubsub`.

Depends-on: https://forge.fedoraproject.org/infra/ansible/pulls/3444 